### PR TITLE
Add height to BigFunLink

### DIFF
--- a/src/components/common/BigFunLink/styled.js
+++ b/src/components/common/BigFunLink/styled.js
@@ -23,6 +23,8 @@ export const StyledLink = styled(Link)`
   }
 
   @media screen and (min-width: ${props => props.theme.MOBILE}) {
+    height: 3rem;
+
     span:last-of-type {
       display: none;
     }


### PR DESCRIPTION
## Description
The English and Japanese characters in `BigFunLink` were rendering at different heights, even though they were both set to `2rem`. By adding a height property to the button on desktop, it stops the flickering.

## Issues
- Fixes #1